### PR TITLE
feat: add statistics feature for URL and parse API.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,10 @@ program
         if(!checkValidUrl(source)) {
             program.error("Invalid URL, verify the structure of the link")
         }
+        if(options.stats) {
+            const statistics = await getStats(source)
+            console.log(statistics)
+        }
     })
     .showHelpAfterError(errorColor("You can execute (url --help) for additional information"))
     .configureOutput({               

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,5 @@
-import { ErrorRequest, ShortenLink, StatisticsLink } from "./types"
+import { ErrorRequest, ShortenLink, StatisticsAPI, StatisticsLink } from "./types"
+import { mappingResponse, statisticsLinkInit } from "./utils"
 
 const SHORTENER_API_KEY = process.env.SHORTENER_API_KEY
 
@@ -37,5 +38,6 @@ export const getStats = async (source: string): Promise<StatisticsLink | ErrorRe
         method: "GET",
         headers
     })
-    return await request.json() as StatisticsLink
+    const response = await request.json() as StatisticsAPI
+    return mappingResponse(response, statisticsLinkInit)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export interface ErrorRequest {
 }
 
 export interface StatisticsLink extends LinkClickStatistics {
-    data: BaseLink
+    data: Pick<BaseLink, "longUrl" | "shortUrl"> & Pick<LinkCreationInfo, "createdAt">
 }
 
 export interface CLIOptions {
@@ -53,4 +53,24 @@ export interface CLIOptions {
     domain: boolean,
     views: boolean,
     long: boolean
+}
+
+
+export interface StatisticsAPI {
+    clicks: number,
+    unique_clicks: number,
+    total_qr_scans: number,
+    browsers: unknown,
+    countries: unknown,
+    referres: unknown,
+    platforms: unknown,
+    daily_clicks: unknown,
+    data: {
+        long_url: string,
+        smart_urls: string[],
+        short_url: string,
+        create_At: Date,
+        last_clicked: Date,
+        total_clicks_last_thirty_days: number
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { StatisticsLink } from "./types"
 
 /**
  * Check if the URL received is a valid URL or it throws an error
@@ -20,4 +21,55 @@ export const checkValidUrl = (url: string): boolean => {
  */
 export const errorColor = (str: string) => {
     return `\x1b[31m${str}\x1b[0m`
+}
+
+
+
+/**
+ * Transform the structure of an object received from the API
+ * and map it to a new object with the values.
+ * 
+ * @param from The response received from the API.
+ * @param to The structure expected to be transformed.
+ * @returns An object of type 'to' with the values received from the API.
+ */
+export const mappingResponse = <From extends object, To extends object>(from: From, to: To): To => {
+    return Object.keys(from).reduce((previous, key) => {
+        const entryKey = underscoreToUppercase(key)
+        if (entryKey in to) {
+            return {
+                ...previous,
+                [entryKey]: from[key as keyof object],
+            }
+        }
+        return previous
+    }, {} as To)
+}
+
+
+/**
+ * Receives a string with underscores and changes the next character to uppercase.
+ * 
+ * @param str The string to be transformed to UpperCamelCase.
+ * @returns The transformed string.
+ */
+const underscoreToUppercase = (str: string): string => {
+    return str
+        .split("_")
+        .map((word, index) => index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1))
+        .join("")
+}
+
+
+/**
+ * Object used to initialize the mapping object.
+ */
+export const statisticsLinkInit: StatisticsLink = {
+    clicks: 0,
+    uniqueClicks: 0,
+    data: {
+        createdAt: "",
+        longUrl: "",
+        shortUrl: ""
+    }
 }


### PR DESCRIPTION
## Description
This pull request introduces two key enhancements to the project:

- `Statistics feature`: Added a new functionality to view statistics for a given URL
- `Response parsing`:  Implemented a function to map attributes from the API response to the project's existing types.

## Checklist
- [x] Documentation.
- [x] The changes don't generate warnings.
- [x] I have performed a self-review of my own code.
- [ ] Tests.