### PR TITLE
chore: update `prettier` config in `package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,19 +53,17 @@
   "prettier": {
     "tabWidth": 4,
     "semi": false,
-    "useTabs": true,
-    "singleQuote": false,
     "printWidth": 130,
     "overrides": [
       {
         "files": [
           "*.json",
-          "README",
+          "*.md",
+          "*.yml",
           "*.yaml"
         ],
         "options": {
-          "tabWidth": 2,
-          "useTabs": false
+          "tabWidth": 2
         }
       }
     ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,56 +22,56 @@ program
  * Configuration of CLI options and arguments
  */
 program
-	.argument("<source-url>", "URL to shorten")
-	.option("-s, --stats", "show the statistics for a URL")
-	.option("-u, --update", "update the current link")
-	.option("-r, --remove", "remove the current link")
-	.option("-d, --domain <domain>", "specify a custom domain")
-	.option("-v, --views", "show the views of a short link")
-	.option("-l, --long", "show the long version of a link")
-	.option("-c, --create", "create a shortened link", true)
-	.option("-i, --short-id <short-id>", "specify a custom identifier for the link")
-	.option("--desc <description>", "add a description associated with the link")
-	.option("--expire-views <views>", "set a limit on the number of views before the link expires")
-	.action(async (source: string, options: CLIOptions) => {
-		if (!checkValidUrl(source)) {
-			program.error("Invalid URL, verify the structure of the link")
-		}
-		if (options.create && !options.stats) {
-			if (options.domain && !checkValidDomain(options.domain)) {
-				program.error("Invalid domain. Verify the structure of the link")
-			}
-			if (options.expireViews && !isNumber(options.expireViews)) {
-				program.error("Invalid expire views argument. The input must be a number.")
-			}
-			if (options.shortId && !isAlphabetNumeric(options.shortId)) {
-				program.error("Invalid short ID. Verify the structure of the short ID.")
-			}
-			const shortened = await shortenerUrl(source, {
-				domain: options.domain,
-				short_id: options.shortId,
-				description: options.description,
-				expire_at_views: parseInt(options.expireViews),
-			})
-			console.log(shortened)
-		}
-		if (options.stats) {
-			const statistics = await getStats(source)
-			console.log(statistics)
-		} else if (options.remove) {
-			const remove = await removeUrl(source)
-			console.log(remove)
-		}
-	})
-	.showHelpAfterError(errorColor("You can execute (shortify --help) for additional information"))
-	.configureOutput({
-		writeErr: (error: string) => {
-			process.stdout.write(`${errorColor("[ERROR]:")} ${error}`)
-		},
-		outputError: (str, write) => {
-			write(errorColor(str))
-		},
-	})
+    .argument("<source-url>", "URL to shorten")
+    .option("-s, --stats", "show the statistics for a URL")
+    .option("-u, --update", "update the current link")
+    .option("-r, --remove", "remove the current link")
+    .option("-d, --domain <domain>", "specify a custom domain")
+    .option("-v, --views", "show the views of a short link")
+    .option("-l, --long", "show the long version of a link")
+    .option("-c, --create", "create a shortened link", true)
+    .option("-i, --short-id <short-id>", "specify a custom identifier for the link")
+    .option("--desc <description>", "add a description associated with the link")
+    .option("--expire-views <views>", "set a limit on the number of views before the link expires")
+    .action(async (source: string, options: CLIOptions) => {
+        if (!checkValidUrl(source)) {
+            program.error("Invalid URL, verify the structure of the link")
+        }
+        if (options.create && !options.stats) {
+            if (options.domain && !checkValidDomain(options.domain)) {
+                program.error("Invalid domain. Verify the structure of the link")
+            }
+            if (options.expireViews && !isNumber(options.expireViews)) {
+                program.error("Invalid expire views argument. The input must be a number.")
+            }
+            if (options.shortId && !isAlphabetNumeric(options.shortId)) {
+                program.error("Invalid short ID. Verify the structure of the short ID.")
+            }
+            const shortened = await shortenerUrl(source, {
+                domain: options.domain,
+                short_id: options.shortId,
+                description: options.description,
+                expire_at_views: parseInt(options.expireViews),
+            })
+            console.log(shortened)
+        }
+        if (options.stats) {
+            const statistics = await getStats(source)
+            console.log(statistics)
+        } else if (options.remove) {
+            const remove = await removeUrl(source)
+            console.log(remove)
+        }
+    })
+    .showHelpAfterError(errorColor("You can execute (shortify --help) for additional information"))
+    .configureOutput({
+        writeErr: (error: string) => {
+            process.stdout.write(`${errorColor("[ERROR]:")} ${error}`)
+        },
+        outputError: (str, write) => {
+            write(errorColor(str))
+        },
+    })
 
 /**
  * Parse the command line arguments

--- a/src/request.ts
+++ b/src/request.ts
@@ -7,9 +7,9 @@ const SHORTENER_API_KEY = process.env.SHORTENER_API_KEY
  * Configuration of the headers for the request to the API
  */
 const headers = {
-	"Content-Type": "application/json",
-	Accept: "application/json",
-	Authorization: `Bearer ${SHORTENER_API_KEY}`,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    Authorization: `Bearer ${SHORTENER_API_KEY}`,
 }
 
 /**
@@ -17,21 +17,21 @@ const headers = {
  * @param source The link to be shortened
  */
 export const shortenerUrl = async (source: string, options: ShortenOptions): Promise<ShortenLink | ErrorRequest> => {
-	const fields = removeEmptyProperties(options)
-	try {
-		const request = await fetch("https://api.t.ly/api/v1/link/shorten", {
-			method: "POST",
-			headers,
-			body: JSON.stringify({
-				long_url: source,
-				...fields,
-			}),
-		})
-		const response = (await request.json()) as ShortenLinkAPI
-		return mappingResponse(response, shortenLinkInit)
-	} catch (error) {
-		return { message: "An error has occurred" }
-	}
+    const fields = removeEmptyProperties(options)
+    try {
+        const request = await fetch("https://api.t.ly/api/v1/link/shorten", {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+                long_url: source,
+                ...fields,
+            }),
+        })
+        const response = (await request.json()) as ShortenLinkAPI
+        return mappingResponse(response, shortenLinkInit)
+    } catch (error) {
+        return { message: "An error has occurred" }
+    }
 }
 
 /**
@@ -40,16 +40,16 @@ export const shortenerUrl = async (source: string, options: ShortenOptions): Pro
  * @param source The shortened link from which the statistics are to be obtained
  */
 export const getStats = async (source: string): Promise<StatisticsLink | ErrorRequest> => {
-	try {
-		const request = await fetch(`https://api.t.ly/api/v1/link/stats?short_url=${source}`, {
-			method: "GET",
-			headers,
-		})
-		const response = (await request.json()) as StatisticsLinkAPI
-		return mappingResponse(response, statisticsLinkInit)
-	} catch (error) {
-		return { message: "An error has occurred" }
-	}
+    try {
+        const request = await fetch(`https://api.t.ly/api/v1/link/stats?short_url=${source}`, {
+            method: "GET",
+            headers,
+        })
+        const response = (await request.json()) as StatisticsLinkAPI
+        return mappingResponse(response, statisticsLinkInit)
+    } catch (error) {
+        return { message: "An error has occurred" }
+    }
 }
 
 /**
@@ -59,16 +59,16 @@ export const getStats = async (source: string): Promise<StatisticsLink | ErrorRe
  * @returns A message to notify that the URL was deleted.
  */
 export const removeUrl = async (source: string): Promise<string> => {
-	try {
-		await fetch("https://api.t.ly/api/v1/link", {
-			method: "DELETE",
-			headers,
-			body: JSON.stringify({
-				short_url: source,
-			}),
-		})
-		return "The link has been successfully removed"
-	} catch (error) {
-		return "An error has occurred"
-	}
+    try {
+        await fetch("https://api.t.ly/api/v1/link", {
+            method: "DELETE",
+            headers,
+            body: JSON.stringify({
+                short_url: source,
+            }),
+        })
+        return "The link has been successfully removed"
+    } catch (error) {
+        return "An error has occurred"
+    }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,58 +1,58 @@
 import type { ToSnakeCase } from "./utility-types"
 
 export interface ExpiredLink {
-	expireAtDatetime: Date
-	expireAtViews: number
+    expireAtDatetime: Date
+    expireAtViews: number
 }
 
 export interface LinkClickStatistics {
-	clicks: number
-	uniqueClicks: number
+    clicks: number
+    uniqueClicks: number
 }
 
 export interface LinkCreationInfo {
-	createdAt: string
-	updtedAt: string
+    createdAt: string
+    updtedAt: string
 }
 
 export interface LinkExtraMetadata {
-	tags: number[]
-	pixels: number[]
+    tags: number[]
+    pixels: number[]
 }
 
 export interface LinkAccess {
-	publicStats: boolean
+    publicStats: boolean
 }
 
 export interface BaseLink {
-	longUrl: string
-	shortUrl: string
-	shortId: string
-	domain: string
-	description: string
+    longUrl: string
+    shortUrl: string
+    shortId: string
+    domain: string
+    description: string
 }
 
 export interface ShortenLink extends BaseLink, LinkCreationInfo {}
 
 export interface ErrorRequest {
-	message: string
+    message: string
 }
 
 export interface StatisticsLink extends LinkClickStatistics {
-	data: Omit<BaseLink, "shortId" | "domain"> & Pick<LinkCreationInfo, "createdAt">
+    data: Omit<BaseLink, "shortId" | "domain"> & Pick<LinkCreationInfo, "createdAt">
 }
 
 export interface CLIOptions {
-	stats: boolean
-	update: boolean
-	remove: boolean
-	domain: string
-	views: boolean
-	long: boolean
-	create: boolean
-	description: string
-	shortId: string
-	expireViews: string
+    stats: boolean
+    update: boolean
+    remove: boolean
+    domain: string
+    views: boolean
+    long: boolean
+    create: boolean
+    description: string
+    shortId: string
+    expireViews: string
 }
 
 export interface ShortenLinkAPI extends ToSnakeCase<ShortenLink> {}
@@ -60,5 +60,5 @@ export interface ShortenLinkAPI extends ToSnakeCase<ShortenLink> {}
 export interface StatisticsLinkAPI extends ToSnakeCase<StatisticsLink> {}
 
 export interface ShortenOptions
-	extends ToSnakeCase<Pick<BaseLink, "shortId" | "domain" | "description">>,
-		ToSnakeCase<Pick<ExpiredLink, "expireAtViews">> {}
+    extends ToSnakeCase<Pick<BaseLink, "shortId" | "domain" | "description">>,
+        ToSnakeCase<Pick<ExpiredLink, "expireAtViews">> {}

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,7 +1,7 @@
 export type SnakeCase<T extends string, A extends string = ""> = T extends `${infer F}${infer R}`
-	? SnakeCase<R, `${A}${F extends Lowercase<F> ? "" : "_"}${Lowercase<F>}`>
-	: A
+    ? SnakeCase<R, `${A}${F extends Lowercase<F> ? "" : "_"}${Lowercase<F>}`>
+    : A
 
 export type ToSnakeCase<T extends Record<string, any>> = {
-	[Key in keyof T as `${SnakeCase<string & Key>}`]: T[Key]
+    [Key in keyof T as `${SnakeCase<string & Key>}`]: T[Key]
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,9 +8,9 @@ import type { ShortenLink, StatisticsLink } from "./types"
  * @returns {true} whether the URL is valid
  */
 export const checkValidUrl = (url: string): boolean => {
-	return new RegExp("^(https?:\\/\\/)?([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}(\\:\\d+)?(\\/[-a-zA-Z0-9@:%_\\+.~#?&//=]*)?$", "i").test(
-		url,
-	)
+    return new RegExp("^(https?:\\/\\/)?([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}(\\:\\d+)?(\\/[-a-zA-Z0-9@:%_\\+.~#?&//=]*)?$", "i").test(
+        url,
+    )
 }
 
 /**
@@ -21,7 +21,7 @@ export const checkValidUrl = (url: string): boolean => {
  * @returns The colored message as a string
  */
 export const errorColor = (str: string) => {
-	return `\x1b[31m${str}\x1b[0m`
+    return `\x1b[31m${str}\x1b[0m`
 }
 
 /**
@@ -33,17 +33,17 @@ export const errorColor = (str: string) => {
  * @returns An object of type 'to' with the values received from the API.
  */
 export const mappingResponse = <From extends Record<string, any>, To extends Record<string, any>>(from: From, to: To): To => {
-	return Object.keys(from).reduce((previous, key) => {
-		const entryKey = underscoreToUppercase(key)
-		if (entryKey in to) {
-			const isObject = typeof from[key] === "object" && from[key]
-			return {
-				...previous,
-				[entryKey]: isObject ? mappingResponse(from[key], to[entryKey]) : from[key],
-			}
-		}
-		return previous
-	}, {} as To)
+    return Object.keys(from).reduce((previous, key) => {
+        const entryKey = underscoreToUppercase(key)
+        if (entryKey in to) {
+            const isObject = typeof from[key] === "object" && from[key]
+            return {
+                ...previous,
+                [entryKey]: isObject ? mappingResponse(from[key], to[entryKey]) : from[key],
+            }
+        }
+        return previous
+    }, {} as To)
 }
 
 /**
@@ -53,24 +53,24 @@ export const mappingResponse = <From extends Record<string, any>, To extends Rec
  * @returns The transformed string.
  */
 const underscoreToUppercase = (str: string): string => {
-	return str
-		.split("_")
-		.map((word, index) => (index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)))
-		.join("")
+    return str
+        .split("_")
+        .map((word, index) => (index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)))
+        .join("")
 }
 
 /**
  * Object used to initialize the mapping object.
  */
 export const statisticsLinkInit: StatisticsLink = {
-	clicks: 0,
-	uniqueClicks: 0,
-	data: {
-		createdAt: "",
-		longUrl: "",
-		shortUrl: "",
-		description: "",
-	},
+    clicks: 0,
+    uniqueClicks: 0,
+    data: {
+        createdAt: "",
+        longUrl: "",
+        shortUrl: "",
+        description: "",
+    },
 }
 
 /**
@@ -86,15 +86,15 @@ export const statisticsLinkInit: StatisticsLink = {
  * @returns The cleaned object.
  */
 export const removeEmptyProperties = <T extends Record<string, any>>(entry: T) => {
-	for (const key in entry) {
-		const pairValue = entry[key]
-		const isArray = Array.isArray(pairValue)
-		const isObject = pairValue && typeof pairValue === "object" && !isArray
-		if (!pairValue || pairValue === "" || (isArray && !pairValue.length) || (isObject && !Object.keys(pairValue).length)) {
-			delete entry[key]
-		}
-	}
-	return entry
+    for (const key in entry) {
+        const pairValue = entry[key]
+        const isArray = Array.isArray(pairValue)
+        const isObject = pairValue && typeof pairValue === "object" && !isArray
+        if (!pairValue || pairValue === "" || (isArray && !pairValue.length) || (isObject && !Object.keys(pairValue).length)) {
+            delete entry[key]
+        }
+    }
+    return entry
 }
 
 /**
@@ -104,7 +104,7 @@ export const removeEmptyProperties = <T extends Record<string, any>>(entry: T) =
  * @returns true if the domain name is valid, false otherwise.
  */
 export const checkValidDomain = (domain: string): boolean => {
-	return new RegExp("^([a-z0-9]+(-[a-z0-9]+)*.)+[a-z]{2,}$").test(domain)
+    return new RegExp("^([a-z0-9]+(-[a-z0-9]+)*.)+[a-z]{2,}$").test(domain)
 }
 
 /**
@@ -114,7 +114,7 @@ export const checkValidDomain = (domain: string): boolean => {
  * @returns true if the sequence is a number, false otherwise.
  */
 export const isNumber = (sequence: string): boolean => {
-	return new RegExp("^[0-9]+$").test(sequence)
+    return new RegExp("^[0-9]+$").test(sequence)
 }
 
 /**
@@ -124,15 +124,15 @@ export const isNumber = (sequence: string): boolean => {
  * @returns true if the sequence is alphanumeric, false otherwise.
  */
 export const isAlphabetNumeric = (sequence: string): boolean => {
-	return new RegExp("^[A-Za-z0-9-_]{1,}$").test(sequence)
+    return new RegExp("^[A-Za-z0-9-_]{1,}$").test(sequence)
 }
 
 export const shortenLinkInit: ShortenLink = {
-	domain: "",
-	createdAt: "",
-	description: "",
-	longUrl: "",
-	shortId: "",
-	shortUrl: "",
-	updtedAt: "",
+    domain: "",
+    createdAt: "",
+    description: "",
+    longUrl: "",
+    shortId: "",
+    shortUrl: "",
+    updtedAt: "",
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest"
 
 describe("Request", () => {
-	test(() => {
-		expect(1).toBe(1)
-	})
+    test(() => {
+        expect(1).toBe(1)
+    })
 })


### PR DESCRIPTION

## Description
Pull Request This pull request updates the Prettier configuration by removing the `useTabs` field from the config in the `package.json` file to eliminate the double spacing created by the tab key. It also runs the format script to apply the changes.

### Key changes
- Remove `useTabs` field
- Add `*.md` and `*.yml` patterns to be added in `overrides` field

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
